### PR TITLE
feat(form): integrate react-hook-form registration

### DIFF
--- a/src/components/Generic/Input/InputField.tsx
+++ b/src/components/Generic/Input/InputField.tsx
@@ -1,8 +1,10 @@
 'use client'
 import type { FC, ReactNode, InputHTMLAttributes } from 'react'
-import React, { useState } from 'react'
+import React, { forwardRef, useState } from 'react'
+import { FieldPath, FieldValues, UseFormRegisterReturn } from 'react-hook-form'
 import { HiExclamation } from 'react-icons/hi'
 import { LuEyeOff, LuEye } from 'react-icons/lu'
+import { mergeRefs } from 'react-laag'
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   type?: 'text' | 'number' | 'email' | 'password' | 'date' | 'time' | string
@@ -11,50 +13,70 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   errorMessage?: string
   startIcon?: ReactNode
   endIcon?: ReactNode
+  registration?: UseFormRegisterReturn<FieldPath<FieldValues>>
 }
 
-const Input: FC<InputProps> = ({
-  type = 'text',
-  className = '',
-  error = false,
-  errorMessage = '',
-  startIcon,
-  endIcon,
-  ...props
-}) => {
-  const [showPassword, setShowPassword] = useState(false)
-  const isPasswordType = type === 'password'
-  const actualType = isPasswordType && showPassword ? 'text' : type
-  const inputClasses = `${error ? 'ring-pink-accent ring-1 focus:ring-2' : 'ring-muted-blue ring-1 focus:ring-3'} ${startIcon ? 'pl-11' : ''} w-full placeholder-muted-blue text-steel-blue focus:outline-hidden rounded-lg px-4 py-2.5 text-sm bg-white ${className}`
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      type = 'text',
+      className = '',
+      error = false,
+      errorMessage = '',
+      startIcon,
+      endIcon,
+      registration,
+      ...props
+    }: InputProps,
+    ref,
+  ) => {
+    const [showPassword, setShowPassword] = useState(false)
+    const isPasswordType = type === 'password'
+    const actualType = isPasswordType && showPassword ? 'text' : type
+    const inputClasses = `${error ? 'ring-pink-accent ring-1 focus:ring-2' : 'ring-muted-blue ring-1 focus:ring-3'} ${startIcon ? 'pl-11' : ''} w-full placeholder-muted-blue text-steel-blue focus:outline-hidden rounded-lg px-4 py-2.5 text-sm bg-white ${className}`
 
-  return (
-    <>
-      <div className="relative">
-        {startIcon && (
-          <span className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5">{startIcon}</span>
-        )}
-        <input type={actualType} className={inputClasses} {...props} />
-        {isPasswordType ? (
-          <button
-            type="button"
-            onClick={() => setShowPassword((prev) => !prev)}
-            className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-blue cursor-pointer"
-            aria-label={showPassword ? 'Hide password' : 'Show password'}
-          >
-            {showPassword ? <LuEyeOff className="w-5 h-5" /> : <LuEye className="w-5 h-5" />}
-          </button>
-        ) : endIcon ? (
-          <span className="absolute right-4 top-1/2 -translate-y-1/2 h-5 w-5">{endIcon}</span>
-        ) : null}
-      </div>
-      {error && errorMessage != '' && (
-        <div className="flex items-center gap-2 text-xs text-pink-accent min-h-[1.25rem] mt-2">
-          <HiExclamation className="w-3 h-3" />
-          <p>{errorMessage}</p>
+    const inputRef = mergeRefs(registration?.ref ?? null, ref)
+
+    const inputProps = registration
+      ? {
+          ...registration,
+          ...props,
+          ref: inputRef,
+        }
+      : {
+          ...props,
+          ref: inputRef,
+        }
+
+    return (
+      <>
+        <div className="relative">
+          {startIcon && (
+            <span className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5">{startIcon}</span>
+          )}
+          <input type={actualType} className={inputClasses} {...props} {...inputProps} />
+          {isPasswordType ? (
+            <button
+              type="button"
+              onClick={() => setShowPassword((prev) => !prev)}
+              className="absolute right-4 top-1/2 -translate-y-1/2 text-muted-blue cursor-pointer"
+              aria-label={showPassword ? 'Hide password' : 'Show password'}
+            >
+              {showPassword ? <LuEyeOff className="w-5 h-5" /> : <LuEye className="w-5 h-5" />}
+            </button>
+          ) : endIcon ? (
+            <span className="absolute right-4 top-1/2 -translate-y-1/2 h-5 w-5">{endIcon}</span>
+          ) : null}
         </div>
-      )}
-    </>
-  )
-}
+        {error && errorMessage != '' && (
+          <div className="flex items-center gap-2 text-xs text-pink-accent min-h-[1.25rem] mt-2">
+            <HiExclamation className="w-3 h-3" />
+            <p>{errorMessage}</p>
+          </div>
+        )}
+      </>
+    )
+  },
+)
 
 export default Input

--- a/src/components/Pages/FormPage/FormView.tsx
+++ b/src/components/Pages/FormPage/FormView.tsx
@@ -165,7 +165,7 @@ const FormView: FC<FormViewProps> = ({ projectData, upcomingSemesters }) => {
       // Exclude these fields from the cleaned data
       ...cleanedData
     } = data
-
+    console.log(cleanedData)
     const res = await handleProjectFormSubmission(cleanedData as CreateProjectRequestBody)
 
     // Handle the response as needed
@@ -487,7 +487,7 @@ const FormView: FC<FormViewProps> = ({ projectData, upcomingSemesters }) => {
                   error={!!errors.specialEquipmentRequirements}
                   errorMessage={errors.specialEquipmentRequirements?.message}
                   defaultValue={projectData?.specialEquipmentRequirements ?? ''}
-                  {...register('specialEquipmentRequirements', {
+                  registration={register('specialEquipmentRequirements', {
                     required: 'Please select one option',
                     validate: (value) => value !== '' || 'Input field must not be empty',
                   })}
@@ -520,7 +520,7 @@ const FormView: FC<FormViewProps> = ({ projectData, upcomingSemesters }) => {
                   error={!!errors.numberOfTeams}
                   errorMessage={errors.numberOfTeams?.message}
                   defaultValue={projectData?.numberOfTeams ?? ''}
-                  {...register('numberOfTeams', {
+                  registration={register('numberOfTeams', {
                     required: 'Number of teams is required',
                     validate: (value) => value !== '' || 'Number of teams is required',
                   })}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the changes towards the related issue. Please also  include relevant context. List any dependencies that are required for this change. -->

This addresses the issue where inputs selected will cancel the custom input and also vice versa. This ticket mocks form events and synthesises an actual event by using `registration`

**Fixes** #523 

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual testing (requires screenshots or videos)
- [ ] Integration tests written (requires checks to pass)

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added thorough tests that prove my fix is effective and that my feature works
- [x] I have written a storybook for frontend components (if applicable)
- [x] I have requested a review from another user
